### PR TITLE
[Feature] 가게 목록 UI 구현

### DIFF
--- a/src/components/stores/SortBottomSheet.jsx
+++ b/src/components/stores/SortBottomSheet.jsx
@@ -1,0 +1,96 @@
+import { useEffect } from "react";
+import { createPortal } from "react-dom";
+import { motion, AnimatePresence } from "framer-motion";
+import styles from "./SortBottomSheet.module.css";
+
+const OPTIONS = [
+  { key: "order", label: "주문많은순" },
+  { key: "distance", label: "가까운순" },
+  { key: "rating", label: "별점높은순" },
+];
+
+export function getSortLabel(sortKey) {
+  const option = OPTIONS.find((opt) => opt.key === sortKey);
+  return option ? option.label : "정렬";
+}
+
+export default function SortBottomSheet({ isOpen, sort, onClose, onSelect }) {
+  // ESC 키로 닫기
+  useEffect(() => {
+    const handleKeyDown = (e) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [onClose]);
+
+  return createPortal(
+    <AnimatePresence>
+      {isOpen && (
+        <>
+          <motion.div
+            className={styles.backdrop}
+            onClick={onClose}
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 0.4 }}
+            exit={{ opacity: 0 }}
+          />
+          <motion.div
+            className={styles.sheet}
+            initial={{ y: "100%" }}
+            animate={{ y: 0 }}
+            exit={{ y: "100%" }}
+            transition={{ duration: 0.25, ease: "easeInOut" }}
+          >
+            <div className={styles.header}>
+              <span className={styles.title}>매장 정렬</span>
+              <button className={styles.close} onClick={onClose}>
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    fill="currentColor"
+                    d="m12 13.4l-4.9 4.9q-.275.275-.7.275t-.7-.275t-.275-.7t.275-.7l4.9-4.9l-4.9-4.9q-.275-.275-.275-.7t.275-.7t.7-.275t.7.275l4.9 4.9l4.9-4.9q.275-.275.7-.275t.7.275t.275.7t-.275.7L13.4 12l4.9 4.9q.275.275.275.7t-.275.7t-.7.275t-.7-.275z"
+                  />
+                </svg>
+              </button>
+            </div>
+            <ul className={styles.optionList}>
+              {OPTIONS.map((opt) => (
+                <li
+                  key={opt.key}
+                  className={styles.optionItem}
+                  onClick={() => {
+                    onSelect(opt.key);
+                    onClose();
+                  }}
+                >
+                  {
+                    sort === opt.key && (
+                      <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        width="18"
+                        height="18"
+                        viewBox="0 0 24 24"
+                        className={styles.checkIcon}
+                      >
+                        <path
+                          fill="currentColor"
+                          d="M9 16.17L4.83 12l-1.41 1.41L9 19 21 7l-1.41-1.41z"
+                        />
+                      </svg>
+                    )}
+                  {opt.label}
+                </li>
+              ))}
+            </ul>
+          </motion.div>
+        </>
+      )}
+    </AnimatePresence>,
+    document.body
+  );
+}

--- a/src/components/stores/SortBottomSheet.module.css
+++ b/src/components/stores/SortBottomSheet.module.css
@@ -1,0 +1,83 @@
+.backdrop {
+  position: fixed;
+  inset: 0;
+  background-color: #000;
+  z-index: 2000;
+}
+
+.sheet {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  margin: 0 auto;
+  background: white;
+  color: var(--black-700);
+  border-radius: 16px 16px 0 0;
+  padding: 16px 0 24px;
+  z-index: 2001;
+  box-shadow: 0 -4px 12px rgba(0, 0, 0, 0.1);
+  box-sizing: border-box;
+}
+/* 태블릿: 768~1023px */
+@media (min-width: 768px) {
+  .sheet {
+    max-width: 720px;
+    border-inline: 1px solid var(--border-color-light);
+  }
+}
+
+/* 데스크탑: 1024px~ */
+@media (min-width: 1024px) {
+  .sheet {
+    max-width: 720px;
+    border-inline: 1px solid var(--border-color-light);
+  }
+}
+
+.header {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: relative;
+  height: 40px;
+  margin-bottom: 16px;
+}
+
+.title {
+  font-weight: bold;
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.close {
+  position: absolute;
+  right: 20px;
+  top: 0;
+  width: 40px;
+  height: 40px;
+  font-size: 18px;
+  background: none;
+  border: none;
+  cursor: pointer;
+}
+
+.optionList {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.optionItem {
+  padding: 16px 0;
+  font-size: 16px;
+  text-align: center;
+  border-top: 1px solid var(--border-color-light);
+  box-sizing: border-box;
+  cursor: pointer;
+}
+.optionItem>svg {
+  margin-right: 8px;
+  color: var(--theme-color);
+  vertical-align: bottom;
+}

--- a/src/components/stores/StoreListItem.jsx
+++ b/src/components/stores/StoreListItem.jsx
@@ -1,4 +1,4 @@
-import styles from './StoreListItem.module.css';
+import styles from "./StoreListItem.module.css";
 
 export default function StoreListItem({ store, onClick }) {
   return (
@@ -22,9 +22,14 @@ export default function StoreListItem({ store, onClick }) {
           />
         </div>
       </div>
-      <h3>{store.name}</h3>
+      <div className={styles.titleFlex}>
+        <h3>{store.name}</h3>
+        <span>{store.minutesToDelivery}분</span>
+      </div>
       <div className={styles.storeInfo}>
-        <span>⭐ {store.review}({store.reviewCount})</span>
+        <span>
+          ⭐ {store.review}({store.reviewCount})
+        </span>
         <span>0.0km</span>
         <span>최소주문 0,000원</span>
       </div>

--- a/src/components/stores/StoreListItem.module.css
+++ b/src/components/stores/StoreListItem.module.css
@@ -12,7 +12,7 @@
 .storeImage {
   flex: 1;
   width: 100px;
-  height: 164px;
+  height: 204px;
   object-fit: cover;
   object-position: center;
 }
@@ -23,8 +23,8 @@
   flex-shrink: 0;
 }
 .menuImage {
-  width: 80px;
-  height: 80px;
+  width: 100px;
+  height: 100px;
   object-fit: cover;
   object-position: center;
 }
@@ -38,16 +38,29 @@
   }
 }
 
+.titleFlex {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+}
 .storeListItem h3 {
+  flex: 1;
   color: var(--black-700);
   font-size: 18px;
   font-weight: 700;
   margin: 12px 0 8px;
 }
+.titleFlex>span {
+  font-size: 15px;
+  color: var(--black-500);
+}
+
 .storeListItem .storeInfo {
   font-size: 14px;
   color: var(--black-500);
 }
-.storeListItem .storeInfo span:not(:last-child)::after {
+.storeListItem .storeInfo>span:not(:last-child)::after {
   content: ' · ';
 }

--- a/src/components/stores/Tabs.jsx
+++ b/src/components/stores/Tabs.jsx
@@ -40,7 +40,8 @@ export default function Tabs() {
 
   const handleTabClick = (category) => {
     setActiveTab(category);
-    setSearchParams({ category }, { replace: true });
+    const params = Object.fromEntries(searchParams.entries());
+    setSearchParams({ ...params, category }, { replace: true });
 
     // 선택된 탭을 가운데로 스크롤
     const el = tabRefs.current[category];

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -43,6 +43,44 @@ function HomeHeader() {
   );
 }
 
+const dummyStores = [
+  {
+    storeId: 1,
+    name: "버거킹 구름점",
+    review: 4.9,
+    reviewCount: 1742,
+    minutesToDelivery: 30,
+  },
+  {
+    storeId: 2,
+    name: "맘스터치 구름점",
+    review: 4.8,
+    reviewCount: 52,
+    minutesToDelivery: 25,
+  },
+  {
+    storeId: 3,
+    name: "청년닭발 구름점",
+    review: 3.1,
+    reviewCount: 124,
+    minutesToDelivery: 40,
+  },
+  {
+    storeId: 4,
+    name: "피자헛 구름점",
+    review: 4.2,
+    reviewCount: 172,
+    minutesToDelivery: 35,
+  },
+  {
+    storeId: 5,
+    name: "청룡각 구름점",
+    review: 4.9,
+    reviewCount: 742,
+    minutesToDelivery: 30,
+  },
+]
+
 export default function Home() {
   const navigate = useNavigate();
   const [keyword, setKeyword] = useState("");
@@ -62,38 +100,15 @@ export default function Home() {
         </div>
       </div>
       <div className={styles.section}>
-          <h2>골라먹는 맛집</h2>
+        <h2>골라먹는 맛집</h2>
+        {dummyStores.map((store) => (
           <StoreListItem
-            store={{ name: "버거킹 구름점", review: 4.9, reviewCount: 1742 }}
-            onClick={() => {
-              navigate("/stores/1");
-            }}
+            key={store.storeId}
+            store={store}
+            onClick={() => navigate(`/stores/${store.storeId}`)}
           />
-          <StoreListItem
-            store={{ name: "맘스터치 구름점", review: 4.8, reviewCount: 52 }}
-            onClick={() => {
-              navigate("/stores/1");
-            }}
-          />
-          <StoreListItem
-            store={{ name: "청년닭발 구름점", review: 3.1, reviewCount: 124 }}
-            onClick={() => {
-              navigate("/stores/2");
-            }}
-          />
-          <StoreListItem
-            store={{ name: "피자헛 구름점", review: 4.2, reviewCount: 172 }}
-            onClick={() => {
-              navigate("/stores/4");
-            }}
-          />
-          <StoreListItem
-            store={{ name: "청룡각 구름점", review: 4.9, reviewCount: 742 }}
-            onClick={() => {
-              navigate("/stores/5");
-            }}
-          />
-        </div>
+        ))}
+      </div>
     </>
   );
 }

--- a/src/pages/stores/StoreList.jsx
+++ b/src/pages/stores/StoreList.jsx
@@ -1,13 +1,69 @@
 import Header from "../../components/common/Header";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import SlideInFromRight from "../../components/animation/SlideInFromRight";
+import StoreListItem from "../../components/stores/StoreListItem";
+import SortBottomSheet, {
+  getSortLabel,
+} from "../../components/stores/SortBottomSheet";
 import Tabs from "../../components/stores/Tabs";
 import { getCategoryName } from "../../utils/categoryUtils";
 
+import styles from "./StoreList.module.css";
+import { useState } from "react";
+
+const dummyStores = [
+  {
+    storeId: 1,
+    name: "버거킹 구름점",
+    review: 4.9,
+    reviewCount: 1742,
+    minutesToDelivery: 30,
+  },
+  {
+    storeId: 2,
+    name: "맘스터치 구름점",
+    review: 4.8,
+    reviewCount: 52,
+    minutesToDelivery: 25,
+  },
+  {
+    storeId: 3,
+    name: "청년닭발 구름점",
+    review: 3.1,
+    reviewCount: 124,
+    minutesToDelivery: 40,
+  },
+  {
+    storeId: 4,
+    name: "피자헛 구름점",
+    review: 4.2,
+    reviewCount: 172,
+    minutesToDelivery: 35,
+  },
+  {
+    storeId: 5,
+    name: "청룡각 구름점",
+    review: 4.9,
+    reviewCount: 742,
+    minutesToDelivery: 30,
+  },
+  {
+    storeId: 6,
+    name: "떡볶이 참 잘하는집 구름점",
+    review: 4.2,
+    reviewCount: 945,
+    minutesToDelivery: 10,
+  },
+];
+
 export default function StoreList() {
   const navigate = useNavigate();
-  const [searchParams] = useSearchParams();
+  const [searchParams, setSearchParams] = useSearchParams();
   const category = searchParams.get("category");
+
+  const sortParam = searchParams.get("sort");
+  const [sort, setSort] = useState(sortParam || "order");
+  const [isSortSheetOpen, setSortSheetOpen] = useState(false);
 
   return (
     <SlideInFromRight>
@@ -23,11 +79,46 @@ export default function StoreList() {
           shadow={false}
         />
         <Tabs />
-        <div
-          style={{ margin: "120px" }}
-        >
-          <h1 style={{ height: "1200px"}}>카테고리별 가게 목록</h1>
+        <div className={styles.container}>
+          <div className={styles.options}>
+            <button
+              className={styles.sortButton}
+              aria-label="정렬 조건"
+              onClick={() => setSortSheetOpen(true)}
+            >
+              <span>{getSortLabel(sort)}</span>
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="18"
+                height="18"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  fill="currentColor"
+                  d="M15.88 9.29L12 13.17L8.12 9.29a.996.996 0 1 0-1.41 1.41l4.59 4.59c.39.39 1.02.39 1.41 0l4.59-4.59a.996.996 0 0 0 0-1.41c-.39-.38-1.03-.39-1.42 0"
+                />
+              </svg>
+            </button>
+          </div>
+          {dummyStores.map((store) => (
+            <StoreListItem
+              key={store.storeId}
+              store={store}
+              onClick={() => navigate(`/stores/${store.storeId}`)}
+            />
+          ))}
         </div>
+
+        <SortBottomSheet
+          sort={sort}
+          isOpen={isSortSheetOpen}
+          onClose={() => setSortSheetOpen(false)}
+          onSelect={(sort) => {
+            setSort(sort);
+            const params = Object.fromEntries(searchParams.entries());
+            setSearchParams({ ...params, sort }, { replace: true });
+          }}
+        />
       </div>
     </SlideInFromRight>
   );

--- a/src/pages/stores/StoreList.module.css
+++ b/src/pages/stores/StoreList.module.css
@@ -1,0 +1,28 @@
+.container {
+  margin-top: 100px;
+  padding-bottom: 40px;
+}
+
+.options {
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-end;
+  align-items: flex-end;
+  height: 44px;
+  margin-bottom: 12px;
+  padding: 0 20px;
+  box-sizing: border-box;
+}
+.sortButton {
+  display: flex;
+  align-items: center;
+  background: none;
+  height: 32px;
+  padding: 0 2px 1px 9px;
+  border-radius: 80px;
+  border: 1px solid var(--border-color);
+  color: var(--black-700);
+  font-size: 12px;
+  cursor: pointer;
+  box-sizing: border-box;
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
 
#8

closes #8 
 
 ## 📝작업 내용
 
### `가게 목록 UI 구현`
  
- 기본 구조 만들기
- 탭 기능 구현하기 (한식, 중식, 버거, 피자, 치킨 등 선택)
- 정렬 조건 선택 기능 구현하기 (가까운순, 주문많은순 등)
- CSS 스타일링

 ### 스크린샷 (선택)

<details>
    <summary>열기</summary>

| 이미지 1 | 이미지 2 |
|----------|----------|
| ![캡처1](https://github.com/user-attachments/assets/13993fab-3026-47e8-9f03-f505000be850) | ![캡처2](https://github.com/user-attachments/assets/fd61de5d-262a-4769-b98c-e3d0a01151f1) |

</details>


 
 ## 💬리뷰 요구사항(선택)
 
- 가게 필터링의 경우 만드는 데 시간이 오래 걸리고 백엔드 개발 상황에 따라 기능이 달라질 거 같아 우선 넘겼습니다. 괜찮을까요?
