### PR TITLE
[Feature] 주소 추가 API 연동

### DIFF
--- a/src/hooks/useAddressRedux.js
+++ b/src/hooks/useAddressRedux.js
@@ -1,9 +1,9 @@
 import { useSelector, useDispatch } from "react-redux";
 import {
-  addAddress,
   updateAddress,
   removeAddress,
   selectAddress,
+  addAddressAsync,
 } from "../store/addressSlice";
 
 export default function useAddressRedux() {
@@ -17,7 +17,7 @@ export default function useAddressRedux() {
     addresses,
     selectedAddressId,
     selectedAddress,
-    addAddress: (address) => dispatch(addAddress(address)),
+    addAddress: (address) => dispatch(addAddressAsync(address)),
     updateAddress: (address) => dispatch(updateAddress(address)),
     removeAddress: (id) => dispatch(removeAddress(id)),
     selectAddress: (id) => dispatch(selectAddress(id)),

--- a/src/pages/address/AddressCurrentLocation.jsx
+++ b/src/pages/address/AddressCurrentLocation.jsx
@@ -288,9 +288,9 @@ export default function AddressCurrentLocation() {
         <div className={styles.addressInfo}>
           <div className={styles.addressText}>
             <h3>선택된 위치</h3>
-            <p className={styles.primaryAddress}>{addressInfo.address}</p>
-            {addressInfo.roadAddress && (
-              <p className={styles.secondaryAddress}>{addressInfo.roadAddress}</p>
+            <p className={styles.primaryAddress}>{addressInfo.roadAddress || addressInfo.address}</p>
+            {(addressInfo.roadAddress) && (
+              <p className={styles.secondaryAddress}>{addressInfo.address}</p>
             )}
           </div>
           

--- a/src/pages/address/AddressEdit.jsx
+++ b/src/pages/address/AddressEdit.jsx
@@ -10,7 +10,7 @@ export default function AddressEdit() {
   const navigate = useNavigate();
   const location = useLocation();
   const { addresses, updateAddress, removeAddress } = useAddressRedux();
-  const addressToEdit = addresses.find((addr) => addr.id === id);
+  const addressToEdit = addresses.find((addr) => addr.id === parseInt(id));
 
   const [currentLabel, setCurrentLabel] = useState("");
   const [detailAddress, setDetailAddress] = useState("");

--- a/src/pages/address/AddressEdit.jsx
+++ b/src/pages/address/AddressEdit.jsx
@@ -10,7 +10,7 @@ export default function AddressEdit() {
   const navigate = useNavigate();
   const location = useLocation();
   const { addresses, updateAddress, removeAddress } = useAddressRedux();
-  const addressToEdit = addresses.find((addr) => addr.id === parseInt(id));
+  const addressToEdit = addresses.find((addr) => addr.id === id);
 
   const [currentLabel, setCurrentLabel] = useState("");
   const [detailAddress, setDetailAddress] = useState("");

--- a/src/pages/address/AddressEdit.module.css
+++ b/src/pages/address/AddressEdit.module.css
@@ -80,13 +80,12 @@
 }
 
 .primaryAddress {
-  margin-bottom: 8px;
   font-weight: 600;
   font-size: 16px;
 }
 
 .secondaryAddress {
-  margin-top: 2px;
+  margin-top: 8px;
   font-size: 14px;
   color: #666;
 }

--- a/src/pages/address/AddressForm.jsx
+++ b/src/pages/address/AddressForm.jsx
@@ -169,8 +169,10 @@ export default function AddressForm({
             className={styles.labelIcon}
           />
           <div className={styles.addressTextGroup}>
-            <p className={styles.primaryAddress}>{currentAddress.address}</p>
-            <p className={styles.secondaryAddress}>{currentAddress.roadAddress}</p>
+            <p className={styles.primaryAddress}>{currentAddress.roadAddress || currentAddress.address}</p>
+            {(currentAddress.roadAddress) && (
+              <p className={styles.secondaryAddress}>{currentAddress.address}</p>
+            )}
             {currentAddress.wowZone && (
               <div className={styles.wowArea}>
                 <span className={styles.wow}>WOW</span>

--- a/src/pages/address/AddressNew.jsx
+++ b/src/pages/address/AddressNew.jsx
@@ -36,7 +36,8 @@ export default function AddressNew() {
 
   // 중복 체크 및 주소 저장 처리
   const handleSubmit = () => {
-    const fullAddress = [currentAddress.address, detailAddress].filter(Boolean).join(' ');
+    const roadAddressOrAddress = currentAddress.roadAddress || currentAddress.address;
+    const fullAddress = [roadAddressOrAddress, detailAddress].filter(Boolean).join(' ');
     const finalLabel = currentLabel === "기타" && customLabel ? customLabel : currentLabel;
     
     const newAddress = {

--- a/src/pages/address/AddressNew.jsx
+++ b/src/pages/address/AddressNew.jsx
@@ -43,6 +43,7 @@ export default function AddressNew() {
       label: finalLabel,
       address: fullAddress,
       roadAddress: currentAddress.roadAddress,
+      detailAddress: detailAddress,
       guide: guideMessage,
       lat: currentAddress.lat,
       lng: currentAddress.lng,

--- a/src/services/addressAPI.js
+++ b/src/services/addressAPI.js
@@ -1,0 +1,45 @@
+import apiClient from "./apiClient";
+import { logger } from "../utils/logger";
+
+const AddressAPI = {
+  // 주소 추가 API
+  createAddress: async (addressData) => {
+    const { label, roadAddress, detailAddress, lat, lng } = addressData;
+
+    if (!label || !roadAddress || lat === undefined || lng === undefined) {
+      throw new Error("필수 주소 정보가 누락되었습니다.");
+    }
+
+    try {
+      // API 명세에 맞춰 변환
+      const newAddress = {
+        mainAddress: roadAddress,
+        detailAddress: detailAddress || "",
+        lat,
+        lng,
+        addressCategory: getAddressLabel(label),
+      }
+
+      const response = await apiClient.post("/addresses", newAddress);
+      logger.log("✅ 주소 추가 성공:", response.data);
+      return response.data.addressId; // 성공적으로 추가된 주소 ID 반환
+
+    } catch (error) {
+      logger.error("📡 주소 추가 요청 실패:", error);
+      throw error;
+    }
+  },
+};
+
+function getAddressLabel(label) {
+  switch (label) {
+    case "집":
+      return "HOUSE";
+    case "회사":
+      return "COMPANY";
+    default:
+      return "NONE";
+  }
+}
+
+export default AddressAPI;

--- a/src/store/addressSlice.js
+++ b/src/store/addressSlice.js
@@ -5,7 +5,7 @@ export const addAddressAsync = createAsyncThunk(
   'address/addAddressAsync',
   async (addressData) => {
     const addressId = await AddressAPI.createAddress(addressData);
-    return { ...addressData, id: addressId };
+    return { ...addressData, id: String(addressId) };
   }
 );
 
@@ -66,16 +66,16 @@ const addressSlice = createSlice({
     },
     removeAddress: (state, action) => {
       state.addresses = state.addresses.filter(
-        (addr) => addr.id !== parseInt(action.payload)
+        (addr) => addr.id !== action.payload
       );
-      if (state.selectedAddressId === parseInt(action.payload)) {
+      if (state.selectedAddressId === action.payload) {
         state.selectedAddressId =
           state.addresses.length > 0 ? state.addresses[0].id : null;
       }
       saveToLocalStorage(state);
     },
     selectAddress: (state, action) => {
-      state.selectedAddressId = parseInt(action.payload);
+      state.selectedAddressId = action.payload;
       saveToLocalStorage(state);
     },
   },

--- a/src/store/addressSlice.js
+++ b/src/store/addressSlice.js
@@ -49,7 +49,13 @@ const saveToLocalStorage = (state) => {
   }
 };
 
-const initialState = loadFromLocalStorage();
+const initialState = {
+  addresses: [],
+  selectedAddressId: null,
+  isLoading: false,
+  error: null,
+  ...loadFromLocalStorage(), // 로컬 스토리지에서 초기 상태 로드
+};
 
 const addressSlice = createSlice({
   name: "address",
@@ -80,7 +86,12 @@ const addressSlice = createSlice({
     },
   },
   extraReducers: (builder) => {
-    builder.addCase(addAddressAsync.fulfilled, (state, action) => {
+    builder
+    .addCase(addAddressAsync.pending, (state) => {
+      state.isLoading = true;
+      state.error = null;
+    })
+    .addCase(addAddressAsync.fulfilled, (state, action) => {
       const newAddress = action.payload;
       state.addresses.push(newAddress);
 
@@ -89,6 +100,10 @@ const addressSlice = createSlice({
       }
 
       saveToLocalStorage(state);
+    })
+    .addCase(addAddressAsync.rejected, (state, action) => {
+      state.isLoading = false;
+      state.error = action.error.message;
     });
   }
 });


### PR DESCRIPTION
## 연관 이슈
#93
closes #93

## 📌 기능 개요
주소 추가 API 연동

## 📌 할 일
- [x] 카카오맵에서 마커로 경도/위도 값 얻기
- [x] 주소 추가 API 연동

## 📌 참고 사항

주소 추가 API를 연동합니다. 새로운 주소 추가시 서버로 요청을 보냅니다.

기존 Redux와 LocalStorage에 저장하던 로직 위에 API 요청 전송 코드만 넣어서 기존 방식과 호환됩니다. 먼저 서버에 주소 추가 요청 전송 -> `addressId`를 응답으로 수신 -> `id` 설정 후 Redux와 LocalStorage에 저장하는 순서로 작동합니다.

아직 목록 조회와 삭제는 서버 API 구현 중으로 연동되지 않았습니다.

![image](https://github.com/user-attachments/assets/2dedfc77-3eb3-404d-8326-3275c555d5a0)
주소 저장 확인됨.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 주소 추가 시 외부 API를 통해 주소가 저장되고, 상세 주소 정보도 함께 저장됩니다.

* **버그 수정**
  * 주소 저장 시 누락되었던 상세 주소 정보가 올바르게 포함됩니다.

* **리팩터**
  * 주소 추가 로직이 비동기 방식으로 변경되어, 저장 성공 시 자동으로 주소 목록과 선택 항목이 갱신됩니다.
  * 주소 표시 우선순위가 도로명 주소를 우선으로 변경되어, 주소 정보가 보다 명확하게 표시됩니다.
  * 주소 관련 UI 스타일이 일부 조정되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->