### PR TITLE
[Feature] 메뉴 조회 API 연동

### DIFF
--- a/db.json
+++ b/db.json
@@ -493,7 +493,7 @@
       "images": ["/samples/food1.jpg"],
       "menus": [
         {
-          "id": 1,
+          "menuId": 1,
           "name": "페퍼로니 피자 L",
           "price": 24900,
           "originalPrice": 27900,
@@ -542,7 +542,7 @@
           ]
         },
         {
-          "id": 2,
+          "menuId": 2,
           "name": "불고기 피자 L",
           "price": 26900,
           "description": "한국인이 사랑하는 불고기 피자",
@@ -550,7 +550,7 @@
           "category": "피자"
         },
         {
-          "id": 3,
+          "menuId": 3,
           "name": "콜라 1.25L",
           "price": 2500,
           "description": "시원한 콜라",
@@ -558,7 +558,7 @@
           "category": "음료"
         },
         {
-          "id": 4,
+          "menuId": 4,
           "name": "테스트 메뉴",
           "price": 6000,
           "description": "테스트용 간단한 메뉴",
@@ -586,7 +586,7 @@
       "images": ["/samples/food2.jpg"],
       "menus": [
         {
-          "id": 5,
+          "menuId": 5,
           "name": "싸이버거 세트",
           "price": 8900,
           "description": "대표 메뉴 싸이버거 세트",
@@ -615,7 +615,7 @@
           ]
         },
         {
-          "id": 6,
+          "menuId": 6,
           "name": "치킨버거",
           "price": 6600,
           "description": "바삭한 치킨 패티 버거",
@@ -643,7 +643,7 @@
       "images": ["/samples/food1.jpg"],
       "menus": [
         {
-          "id": 7,
+          "menuId": 7,
           "name": "굽네 볼케이노",
           "price": 19900,
           "description": "매콤한 볼케이노 치킨",

--- a/src/components/common/Header.module.css
+++ b/src/components/common/Header.module.css
@@ -43,6 +43,7 @@
     justify-content: center;
     color: var(--black-700);
     cursor: pointer;
+    z-index: 1002;
 }
 .iconButton:hover {
     background-color: var(--background-hover-color);

--- a/src/components/stores/AutoScrollTabs.jsx
+++ b/src/components/stores/AutoScrollTabs.jsx
@@ -3,10 +3,10 @@ import MenuItem from "./MenuItem";
 import styles from "./AutoScrollTabs.module.css";
 
 export default function AutoScrollTabs({ storeId, menus, fixed = false }) {
-   const menuGroups = menus
-    .map((menu) => menu.menuGroupName)
+  const menuGroups = menus
+    .map((menu) => menu.groupName)
     .filter((group, index, self) => self.indexOf(group) === index);
-  
+
   const [activeTab, setActiveTab] = useState(menuGroups[0]);
   const sectionRefs = useRef({});
   const tabRefs = useRef({});
@@ -51,7 +51,7 @@ export default function AutoScrollTabs({ storeId, menus, fixed = false }) {
     });
 
     return () => observer.disconnect();
-  }, []);
+  }, [menus]);
 
   return (
     <div className={styles.wrapper}>
@@ -85,7 +85,7 @@ export default function AutoScrollTabs({ storeId, menus, fixed = false }) {
           >
             <h2 className={styles.subHeader}>{group}</h2>
             {menus
-              .filter((menu) => menu.menuGroupName === group)
+              .filter((menu) => menu.groupName === group)
               .map((menu) => (
                 <MenuItem key={menu.menuId} storeId={storeId} menu={menu} />
               ))}

--- a/src/components/stores/HeaderMenuDetail.module.css
+++ b/src/components/stores/HeaderMenuDetail.module.css
@@ -2,6 +2,17 @@
   background-color: transparent;
   transition: all 0.3s ease-in-out;
 }
+.headerTransparent::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 48px;
+  background: linear-gradient(to bottom, rgba(0, 0, 0, 0.35), transparent);
+  pointer-events: none;
+  z-index: 500;
+}
 
 .iconButtonContainer {
   display: flex;

--- a/src/components/stores/HeaderStoreDetail.module.css
+++ b/src/components/stores/HeaderStoreDetail.module.css
@@ -2,6 +2,17 @@
   background-color: transparent;
   transition: all 0.3s ease-in-out;
 }
+.headerTransparent::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 48px;
+  background: linear-gradient(to bottom, rgba(0, 0, 0, 0.35), transparent);
+  pointer-events: none;
+  z-index: 500;
+}
 
 .iconButtonContainer {
   display: flex;
@@ -9,6 +20,7 @@
   align-items: center;
   justify-content: center;
   gap: 4px;
+  z-index: 1002;
 }
 .headerTransparent button > svg {
   color: #fff;

--- a/src/components/stores/MenuItem.jsx
+++ b/src/components/stores/MenuItem.jsx
@@ -9,7 +9,7 @@ const MenuItem = React.memo(({ storeId, menu }) => {
   const isSoldOut = menu.menuStatus === "OUT_OF_STOCK";
 
   const handleClick = useCallback(() => {
-    const menuId = menu.menuId || menu.id;
+    const menuId = menu.menuId;
     navigate(`/stores/${storeId}/menus/${menuId}`);
   }, [navigate, storeId, menu.menuId, menu.id]);
 

--- a/src/components/stores/MenuItem.jsx
+++ b/src/components/stores/MenuItem.jsx
@@ -29,8 +29,8 @@ const MenuItem = React.memo(({ storeId, menu }) => {
             src={menu.image || menu.imageUrl}
             alt={menu.menuName || menu.name}
             className={`${styles.menuImage} ${isSoldOut ? styles.dimmed : ""}`}
-            width={80}
-            height={80}
+            width={100}
+            height={100}
             priority={false}
             placeholder="/samples/favoriteDefault.png"
           />
@@ -42,8 +42,8 @@ const MenuItem = React.memo(({ storeId, menu }) => {
             src="/samples/favoriteDefault.png"
             alt="기본 메뉴 이미지"
             className={styles.menuImage}
-            width={80}
-            height={80}
+            width={100}
+            height={100}
             priority={false}
           />
         </div>

--- a/src/hooks/useFavorite.js
+++ b/src/hooks/useFavorite.js
@@ -152,6 +152,7 @@ function useFavorite() {
     navigateToHome,
     toggleFavorite,
     isFavorite,
+    setIsFavorite,
   };
 }
 

--- a/src/hooks/useFavorite.js
+++ b/src/hooks/useFavorite.js
@@ -1,7 +1,6 @@
 // useFavorite.js
 import { useState, useMemo, useEffect } from "react";
 import { useSelector, useDispatch } from "react-redux";
-import { fetchStores } from "../store/storeSlice";
 import { useNavigate } from "react-router-dom";
 import { STORAGE_KEYS, logger } from '../utils/logger';
 
@@ -17,16 +16,6 @@ function useFavorite() {
     storeLoading,
     firstStore: stores[0]
   });
-
-  // stores 데이터가 없으면 직접 로드
-  useEffect(() => {
-    if (stores.length === 0 && !storeLoading) {
-      logger.log('🔄 useFavorite에서 fetchStores 호출');
-      dispatch(fetchStores()).catch(error => {
-        logger.error('매장 데이터 로드 실패:', error);
-      });
-    }
-  }, [stores.length, storeLoading, dispatch]);
   
   // localStorage에서 즐겨찾기 ID 목록 불러오기
   const [favoriteStoreIds, setFavoriteStoreIds] = useState(() => {
@@ -124,6 +113,22 @@ function useFavorite() {
   // 즐겨찾기 여부 확인
   const isFavorite = (storeId) => {
     return favoriteStoreIds.some(id => String(id) === String(storeId));
+  };
+
+  // 즐겨찾기 여부 설정
+  const setIsFavorite = (storeId, isFav) => {
+    setFavoriteStoreIds((prev) => {
+      const normalizedStoreId = String(storeId);
+      const normalizedPrev = prev.map(String);
+      
+      if (isFav) {
+        return normalizedPrev.includes(normalizedStoreId)
+          ? prev
+          : [...prev, storeId];
+      } else {
+        return prev.filter((id) => String(id) !== normalizedStoreId);
+      }
+    });
   };
 
   const sortedFavorites = useMemo(() => {

--- a/src/hooks/useFavorite.js
+++ b/src/hooks/useFavorite.js
@@ -11,12 +11,6 @@ function useFavorite() {
   const stores = useSelector(state => state.store?.stores || []);
   const storeLoading = useSelector(state => state.store?.loading || false);
   
-  logger.log('🏪 useFavorite - Redux stores 상태:', {
-    storesCount: stores.length,
-    storeLoading,
-    firstStore: stores[0]
-  });
-  
   // localStorage에서 즐겨찾기 ID 목록 불러오기
   const [favoriteStoreIds, setFavoriteStoreIds] = useState(() => {
     // LocalStorage에서 즐겨찾기 목록 복원

--- a/src/pages/orders/Cart.jsx
+++ b/src/pages/orders/Cart.jsx
@@ -152,7 +152,7 @@ export default function Cart() {
       } else if (firstMenu?.menuId) {
         const foundStore = allStores.find(store => 
           store.menus && store.menus.some(menu => 
-            String(menu.id) === String(firstMenu.menuId)
+            String(menu.menuId) === String(firstMenu.menuId)
           )
         );
         

--- a/src/pages/stores/StoreDetail.jsx
+++ b/src/pages/stores/StoreDetail.jsx
@@ -23,7 +23,7 @@ export default function StoreDetail() {
   const navigate = useNavigate();
   const dispatch = useDispatch();
   const { copyToClipboard, shareViaWebAPI } = useShare();
-  const { toggleFavorite } = useFavorite();
+  const { toggleFavorite, setIsFavorite } = useFavorite();
 
   const { storeId } = useParams();
 

--- a/src/pages/stores/StoreDetail.jsx
+++ b/src/pages/stores/StoreDetail.jsx
@@ -195,7 +195,7 @@ export default function StoreDetail() {
             <h1>{currentStore.name}</h1>
             <div className={styles.storeInfoButton}>
               <span>
-                ⭐ {currentStore.review}({currentStore.reviewCount})
+                ⭐ {currentStore.review?.toFixed(1)} ({currentStore.reviewCount})
               </span>
               <svg
                 xmlns="http://www.w3.org/2000/svg"

--- a/src/services/storeAPI.js
+++ b/src/services/storeAPI.js
@@ -53,7 +53,7 @@ const StoreAPI = {
   // 메뉴 옵션 조회 API
   getMenuOptionsByMenuId: async (storeId, menuId) => {
     try {
-      const response = await apiClient.get(`/stores/${storeId}/${menuId}/options`);
+      const response = await apiClient.get(`/stores/${storeId}/menus/${menuId}/options`);
       logger.log("✅ 매장 메뉴 옵션 조회 성공:", response.data);
       return response.data;
     } catch (error) {

--- a/src/services/storeAPI.js
+++ b/src/services/storeAPI.js
@@ -50,6 +50,17 @@ const StoreAPI = {
       throw error;
     }
   },
+  // 메뉴 옵션 조회 API
+  getMenuOptionsByMenuId: async (storeId, menuId) => {
+    try {
+      const response = await apiClient.get(`/stores/${storeId}/${menuId}/options`);
+      logger.log("✅ 매장 메뉴 옵션 조회 성공:", response.data);
+      return response.data;
+    } catch (error) {
+      logger.error("📡 매장 메뉴 옵션 조회 요청 실패:", error);
+      throw error;
+    }
+  },
 };
 
 export default StoreAPI;

--- a/src/services/storeAPI.js
+++ b/src/services/storeAPI.js
@@ -28,6 +28,28 @@ const StoreAPI = {
       throw error;
     }
   },
+  // 매장 상세 정보 조회 API
+  getStoreById: async (storeId) => {
+    try {
+      const response = await apiClient.get(`/stores/${storeId}`);
+      // logger.log("✅ 매장 상세 정보 조회 성공:", response.data);
+      return response.data;
+    } catch (error) {
+      logger.error("📡 매장 상세 정보 조회 요청 실패:", error);
+      throw error;
+    }
+  },
+  // 메뉴 조회 API
+  getMenusByStoreId: async (storeId) => {
+    try {
+      const response = await apiClient.get(`/stores/${storeId}/menus`);
+      // logger.log("✅ 매장 메뉴 조회 성공:", response.data);
+      return response.data;
+    } catch (error) {
+      logger.error("📡 매장 메뉴 조회 요청 실패:", error);
+      throw error;
+    }
+  },
 };
 
 export default StoreAPI;

--- a/src/store/storeSlice.js
+++ b/src/store/storeSlice.js
@@ -70,7 +70,8 @@ const storeSlice = createSlice({
       state.currentStore = action.payload;
     },
     clearCurrentStore(state) {
-      state.currentStore = null;
+      state.currentStore = {};
+      state.currentMenu = {};
     },
   },
   extraReducers: (builder) => {
@@ -141,10 +142,9 @@ const storeSlice = createSlice({
           !state.currentStore ||
           state.currentStore.storeId !== action.payload.storeId
         ) {
-          state.currentStore =
-            state.stores.find(
-              (store) => store.storeId === action.payload.storeId
-            ) || {};
+          state.currentStore = state.stores.find(
+            (store) => store.storeId === action.payload.storeId
+          ) || { storeId: action.payload.storeId };
         }
 
         // 메뉴 그룹별로 나눠진 메뉴를 평탄화

--- a/src/utils/storeUtils.js
+++ b/src/utils/storeUtils.js
@@ -40,7 +40,7 @@ export const findOrCreateStoreInfo = (orderMenus, allStores, logger) => {
   if (!currentStoreInfo && firstMenu.menuId) {
     const foundByMenuId = allStores.find(store => 
       store.menus && store.menus.some(menu => 
-        String(menu.id) === String(firstMenu.menuId)
+        String(menu.menuId) === String(firstMenu.menuId)
       )
     );
     


### PR DESCRIPTION
## 연관 이슈
#104
closes #104

## 📌 기능 개요
메뉴 조회, 메뉴 옵션 조회 API를 연동합니다.

## 📌 할 일
- [x] 가게 상세 정보 조회 연동
- [x] 메뉴 조회 조회 연동
- [x] 메뉴 옵션 조회 연동

## 📌 참고 사항

![image](https://github.com/user-attachments/assets/b2fa85fb-33e0-4a9e-b0c2-d026612f5692)

메뉴 및 메뉴 옵션 조회 확인됨.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 매장, 메뉴, 메뉴 옵션에 대한 상세 데이터를 불러오는 기능이 추가되었습니다.
  * 즐겨찾기 매장 설정 및 해제 기능이 개선되었습니다.

* **버그 수정**
  * 즐겨찾기 상태 동기화 및 표시 방식이 개선되었습니다.
  * 메뉴 옵션 데이터 구조 및 표기 방식이 일관성 있게 수정되었습니다.
  * 메뉴 식별자 비교 로직이 정확하게 변경되었습니다.

* **스타일**
  * 헤더 및 아이콘 버튼에 z-index와 그라데이션 오버레이가 적용되어 시각적 계층과 가독성이 향상되었습니다.
  * 메뉴 이미지 크기가 100x100픽셀로 확대되었습니다.

* **리팩터**
  * 메뉴 및 옵션 데이터 구조가 변경되어 데이터 일관성이 개선되었습니다.

* **데이터**
  * 메뉴 데이터의 키 이름이 일관성 있게 변경되었습니다. (id → menuId)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->