### PR TITLE
[Feature] 가게 검색 API 연동

### DIFF
--- a/src/components/common/SearchHeaderBar.jsx
+++ b/src/components/common/SearchHeaderBar.jsx
@@ -40,6 +40,11 @@ export default function SearchHeaderBar({ keyword, onChange, onSearch, onBack })
         className={styles.searchInput}
         value={keyword}
         onChange={onChange}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") {
+            onSearch();
+          }
+        }}
       />
       <button className={styles.searchBtn} onClick={onSearch}>
         <SearchIcon className={styles.icon}/>

--- a/src/components/common/SearchInput.jsx
+++ b/src/components/common/SearchInput.jsx
@@ -3,6 +3,7 @@ import styles from "./SearchInput.module.css";
 export default function SearchInput({
   value,
   onChange,
+  onKeyDown,
   placeholder = "검색어를 입력해주세요",
   showIcon = false,
   className = "",
@@ -22,6 +23,7 @@ export default function SearchInput({
         className={styles.input}
         value={value}
         onChange={onChange}
+        onKeyDown={onKeyDown}
         placeholder={placeholder}
       />
     </div>

--- a/src/modules/index.js
+++ b/src/modules/index.js
@@ -2,19 +2,21 @@
 import { combineReducers } from "redux";
 import cart from "../store/cartSlice";
 import counter from "./counterModule";
-import paymentReducer from "../store/paymentSlice"; // ✅ 추가
+import paymentReducer from "../store/paymentSlice";
 import addressReducer from "../store/addressSlice";
 import orderReducer from "../store/orderSlice";
 import couponReducer from "../store/couponSlice";
-import storeReducer from "../store/storeSlice"; // ✅ storeReducer 추가
+import storeReducer from "../store/storeSlice";
+import searchReducer from "../store/searchSlice";
 
 const rootReducer = combineReducers({
   cart, counter,
-  payment: paymentReducer, // ✅ 여기에 추가!
+  payment: paymentReducer,
   address: addressReducer,
   order: orderReducer,
-  coupon: couponReducer, // ✅ 쿠폰 리듀서 추가
-  store: storeReducer, // ✅ 매장 리듀서 추가
+  coupon: couponReducer,
+  store: storeReducer,
+  search: searchReducer,
 });
 
 export default rootReducer;

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -107,8 +107,8 @@ export default function Home() {
   }, [dispatch]);
 
   const handleSearchStores = useCallback(() => {
-    navigate("/search");
-  }, [navigate]);
+    navigate(`/search-result?keyword=${encodeURIComponent(keyword)}`);
+  }, [navigate, keyword]);
 
   // useMemo로 장바구니 정보 계산 최적화
   const cartInfo = useMemo(() => {
@@ -185,6 +185,12 @@ export default function Home() {
         <SearchInput
           value={keyword}
           onChange={handleKeywordChange}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              handleSearchStores();
+            }
+          }}
           showIcon={true}
         />
         <MenuGrid />

--- a/src/pages/search/Search.jsx
+++ b/src/pages/search/Search.jsx
@@ -2,6 +2,8 @@ import React, { useState } from "react";
 import styles from "../search/Search.module.css";
 import SearchHeaderBar from "../../components/common/SearchHeaderBar";
 import { useNavigate } from "react-router-dom";
+import { useSelector, useDispatch } from "react-redux";
+import { addKeyword, removeKeyword, clearKeywords } from "../../store/searchSlice";
 
 const watchIcon = (
   <svg 
@@ -18,46 +20,28 @@ const watchIcon = (
 
 export default function Search() {
   const navigate = useNavigate();
+  const dispatch = useDispatch();
 
   // 최근 검색어
-  const [recentKeywords, setRecentKeywords] = useState([
-    {keyword: "삽겹살", date: "06.01"},
-    {keyword: "햄버거", date: "05.31"},
-  ]);
+  const recentKeywords = useSelector(state => {console.log(state);  return state.search?.keywords || []});
 
   const [keyword, setKeyword] = useState("");
-
-  // 최근 검색어 추가
-  const handleAddKeyword = (text) => {
-    if (text === undefined || text === "") {
-      return;
-    }
-
-    const today = new Date();
-    const date = `${String(today.getMonth() + 1).padStart(2, "0")}.${String(today.getDate()).padStart(2, "0")}`;
-
-    const newKeyword = { keyword: text, date: date };
-
-    setRecentKeywords((prev) => {
-      // 중복 제거
-      const filtered = prev.filter((item) => item.keyword !== text);
-      return [newKeyword, ...filtered];
-    });
-  };
 
   const handleSearch = (text) => {
     if (!text || text === "") {
       return;
     }
-    // 키워드 저장
-    handleAddKeyword(text);
     navigate(`/search-result?keyword=${encodeURIComponent(text)}`);
   }
 
   // 최근 검색어 삭제
   const handleRemoveKeyword = (keyword) => {
-    const filtered = recentKeywords.filter((item) => item.keyword !== keyword);
-    setRecentKeywords(filtered);
+    dispatch(removeKeyword(keyword));
+  }
+
+  // 최근 검색어 전체 삭제
+  const handleClearKeyword = () => {
+    dispatch(clearKeywords());
   }
 
   // 최근 검색어 눌렀을때
@@ -91,7 +75,7 @@ export default function Search() {
       <div>
         <div className={styles.keywordHeader}>
           <span className={styles.title}>최근 검색어</span>
-          <button className={styles.subTextRight}>전체삭제</button>
+          <button className={styles.subTextRight} onClick={handleClearKeyword}>전체삭제</button>
         </div>
           <ul className={styles.recentList}>
             <ul className={styles.recentList}>

--- a/src/pages/search/SearchResults.jsx
+++ b/src/pages/search/SearchResults.jsx
@@ -6,11 +6,12 @@ import StoreListItem from "../../components/stores/StoreListItem";
 import SortBottomSheet, {
   getSortLabel,
 } from "../../components/stores/SortBottomSheet";
-import { fetchStores } from "../../store/storeSlice";
+import { fetchStoresByKeyword, clearCurrentStore } from "../../store/storeSlice";
 import LoadingSpinner from "../../components/common/LoadingSpinner";
 import EmptyState from "../../components/common/EmptyState";
 import ErrorState from "../../components/common/ErrorState";
 import { useListUIState, getErrorVariant } from "../../hooks/useUIState";
+import useAddressRedux from "../../hooks/useAddressRedux";
 import styles from "../stores/StoreList.module.css";
 
 export default function SearchResult() {
@@ -18,40 +19,62 @@ export default function SearchResult() {
   const dispatch = useDispatch();
   const [searchParams, setSearchParams] = useSearchParams();
   const initialKeyword = searchParams.get("keyword") || "";
+  const [searchedKeyword, setSearchedKeyword] = useState(initialKeyword); // 검색어 표시용
   const [keyword, setKeyword] = useState(initialKeyword);
 
   const sortParam = searchParams.get("sort");
   const [sort, setSort] = useState(sortParam || "DISTANCE");
   const [isSortSheetOpen, setSortSheetOpen] = useState(false);
-  
+
   // Redux에서 매장 데이터 가져오기
   const stores = useSelector((state) => state.store?.stores || []);
   const storeLoading = useSelector((state) => state.store?.loading || false);
   const storeError = useSelector((state) => state.store?.error || null);
+  const { selectedAddressId } = useAddressRedux();
 
   // UI 상태 관리
   const uiState = useListUIState({
     isLoading: storeLoading,
     error: storeError,
-    items: filteredAndSortedStores,
+    items: stores,
     searchKeyword: keyword,
-    emptyVariant: 'search'
+    emptyVariant: "search",
   });
-  
+
   useEffect(() => {
+    setSearchedKeyword(initialKeyword);
     setKeyword(initialKeyword);
-  }, [initialKeyword]);
-  
-  // 매장 데이터가 없으면 로딩
-  useEffect(() => {
-    if (stores.length === 0 && !storeLoading) {
-      dispatch(fetchStores());
-    }
-  }, [dispatch, stores.length, storeLoading]);
+    dispatch(fetchStoresByKeyword({
+      keyword: initialKeyword,
+      sort,
+      page: 0,
+      addressId: selectedAddressId,
+    }));
+  }, []);
 
   // 에러 핸들러
   const handleRetry = () => {
-    dispatch(fetchStores());
+    dispatch(
+      fetchStoresByKeyword({
+        keyword,
+        sort,
+        page: 0,
+        addressId: selectedAddressId,
+      })
+    );
+    setSearchedKeyword(keyword);
+  };
+
+  const handleSearch = () => {
+    dispatch(
+      fetchStoresByKeyword({
+        keyword,
+        sort,
+        page: 0,
+        addressId: selectedAddressId,
+      })
+    );
+    setSearchedKeyword(keyword);
   };
 
   const handleGoBack = () => {
@@ -61,13 +84,7 @@ export default function SearchResult() {
   // UI 상태별 렌더링
   const renderContent = () => {
     if (uiState.isLoading) {
-      return (
-        <LoadingSpinner 
-          message="검색 중..." 
-          size="medium"
-          pageLoading
-        />
-      );
+      return <LoadingSpinner message="검색 중..." size="medium" pageLoading />;
     }
 
     if (uiState.hasError) {
@@ -86,7 +103,7 @@ export default function SearchResult() {
       return (
         <EmptyState
           variant="search"
-          title={`"${keyword}"에 대한 검색 결과가 없습니다`}
+          title={`"${searchedKeyword}"에 대한 검색 결과가 없습니다`}
           description="다른 키워드로 검색해보세요"
           actionText="돌아가기"
           onAction={handleGoBack}
@@ -99,10 +116,10 @@ export default function SearchResult() {
       <>
         <div className={styles.searchInfo}>
           <span className={styles.resultCount}>
-            "{keyword}" 검색 결과 {uiState.itemCount}개
+            "{searchedKeyword}" 검색 결과 {uiState.itemCount}개
           </span>
         </div>
-        
+
         {stores.map((store) => (
           <StoreListItem
             key={store.storeId}
@@ -114,7 +131,8 @@ export default function SearchResult() {
               images: store.images || ["/samples/food1.jpg"],
               distance: store.distance || 1,
               minOrderPrice: store.minOrderPrice || 10000,
-              minutesToDelivery: parseInt(store.deliveryTime?.split('-')[0]) || 30
+              minutesToDelivery:
+                parseInt(store.deliveryTime?.split("-")[0]) || 30,
             }}
             onClick={() => navigate(`/stores/${store.storeId}`)}
           />
@@ -122,14 +140,16 @@ export default function SearchResult() {
       </>
     );
   };
-  
+
   return (
     <>
-      <SearchHeaderBar 
+      <SearchHeaderBar
         keyword={keyword}
         onBack={handleGoBack}
+        onChange={(e) => setKeyword(e.target.value)}
+        onSearch={handleSearch}
       />
-      
+
       {/* 정렬 옵션은 검색 결과가 있을 때만 표시 */}
       {uiState.hasData && (
         <div className={styles.options}>
@@ -145,10 +165,10 @@ export default function SearchResult() {
               height="18"
               viewBox="0 0 24 24"
             >
-            <path
-              fill="currentColor"
-              d="M15.88 9.29L12 13.17L8.12 9.29a.996.996 0 1 0-1.41 1.41l4.59 4.59c.39.39 1.02.39 1.41 0l4.59-4.59a.996.996 0 0 0 0-1.41c-.39-.38-1.03-.39-1.42 0"
-            />
+              <path
+                fill="currentColor"
+                d="M15.88 9.29L12 13.17L8.12 9.29a.996.996 0 1 0-1.41 1.41l4.59 4.59c.39.39 1.02.39 1.41 0l4.59-4.59a.996.996 0 0 0 0-1.41c-.39-.38-1.03-.39-1.42 0"
+              />
             </svg>
           </button>
         </div>
@@ -156,7 +176,7 @@ export default function SearchResult() {
 
       {/* 메인 콘텐츠 */}
       {renderContent()}
-      
+
       {/* 정렬 바텀시트 */}
       <SortBottomSheet
         sort={sort}

--- a/src/pages/search/SearchResults.jsx
+++ b/src/pages/search/SearchResults.jsx
@@ -12,6 +12,7 @@ import EmptyState from "../../components/common/EmptyState";
 import ErrorState from "../../components/common/ErrorState";
 import { useListUIState, getErrorVariant } from "../../hooks/useUIState";
 import useAddressRedux from "../../hooks/useAddressRedux";
+import { addKeyword } from "../../store/searchSlice";
 import styles from "../stores/StoreList.module.css";
 
 export default function SearchResult() {
@@ -43,6 +44,7 @@ export default function SearchResult() {
 
   useEffect(() => {
     setSearchedKeyword(initialKeyword);
+    handleAddKeyword(keyword);
     setKeyword(initialKeyword);
     dispatch(fetchStoresByKeyword({
       keyword: initialKeyword,
@@ -75,6 +77,16 @@ export default function SearchResult() {
       })
     );
     setSearchedKeyword(keyword);
+    handleAddKeyword(keyword);
+  };
+
+  // 최근 검색어 추가
+  const handleAddKeyword = (keyword) => {
+    if (keyword === undefined || keyword === "") {
+      return;
+    }
+
+    dispatch(addKeyword(keyword));
   };
 
   const handleGoBack = () => {

--- a/src/services/storeAPI.js
+++ b/src/services/storeAPI.js
@@ -28,6 +28,19 @@ const StoreAPI = {
       throw error;
     }
   },
+  // 매장 검색 API
+  searchStores: async ({ keyword, sort, page, addressId }) => {
+    try {
+      const response = await apiClient.get("/search/stores/list", {
+        params: { keyword, sort, page, addressId: Number(addressId) || null },
+      });
+      // logger.log("✅ 매장 검색 성공:", response.data);
+      return response.data;
+    } catch (error) {
+      logger.error("📡 매장 검색 요청 실패:", error);
+      throw error;
+    }
+  },
   // 매장 상세 정보 조회 API
   getStoreById: async (storeId) => {
     try {

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -6,7 +6,9 @@ import addressReducer from "./addressSlice";
 import orderReducer from "./orderSlice";
 import couponReducer from "./couponSlice";
 import storeReducer from "./storeSlice";
+import searchReducer from "./searchSlice";
 
+// 이 파일은 사용되지 않음 (2025/07/08)
 const store = configureStore({
   reducer: {
     cart: cartReducer,
@@ -15,6 +17,7 @@ const store = configureStore({
     order: orderReducer,
     coupon: couponReducer,
     store: storeReducer,
+    search: searchReducer,
   },
 });
 

--- a/src/store/searchSlice.js
+++ b/src/store/searchSlice.js
@@ -1,0 +1,66 @@
+import { createSlice } from '@reduxjs/toolkit';
+import { STORAGE_KEYS } from "../utils/logger";
+
+// localStorage에서 초기값 불러오기
+const loadFromStorage = () => {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEYS.RECENT_SEARCHES);
+    return stored ? JSON.parse(stored) : [];
+  } catch (e) {
+    console.error('Failed to load recent keywords from storage', e);
+    return [];
+  }
+};
+
+// localStorage에 저장
+const saveToStorage = (keywords) => {
+  try {
+    localStorage.setItem(STORAGE_KEYS.RECENT_SEARCHES, JSON.stringify(keywords));
+  } catch (e) {
+    console.error('Failed to save recent keywords to storage', e);
+  }
+};
+
+const MAX_COUNT = 6;
+
+const initialState = {
+  keywords: loadFromStorage(),
+};
+
+const searchSlice = createSlice({
+  name: 'search',
+  initialState,
+  reducers: {
+    addKeyword: (state, action) => {
+      const keyword = action.payload.trim();
+      const today = new Date();
+      const date = `${String(today.getMonth() + 1).padStart(2, '0')}.${String(today.getDate()).padStart(2, '0')}`;
+
+      // 중복 제거
+      state.keywords = state.keywords.filter(item => item.keyword !== keyword);
+
+      // 앞에 추가
+      state.keywords.unshift({ keyword, date });
+
+      // 최대 개수 유지
+      if (state.keywords.length > MAX_COUNT) {
+        state.keywords.pop();
+      }
+
+      saveToStorage(state.keywords);
+    },
+
+    removeKeyword: (state, action) => {
+      state.keywords = state.keywords.filter(item => item.keyword !== action.payload);
+      saveToStorage(state.keywords);
+    },
+
+    clearKeywords: (state) => {
+      state.keywords = [];
+      saveToStorage([]);
+    },
+  },
+});
+
+export const { addKeyword, removeKeyword, clearKeywords } = searchSlice.actions;
+export default searchSlice.reducer;

--- a/src/store/storeSlice.js
+++ b/src/store/storeSlice.js
@@ -25,6 +25,20 @@ export const fetchStoresByCategory = createAsyncThunk(
   }
 );
 
+// 매장 검색 API 연동
+export const fetchStoresByKeyword = createAsyncThunk(
+  "store/fetchStoresByKeyword",
+  async ({ keyword, sort, page, addressId }) => {
+    const data = await StoreAPI.searchStores({
+      keyword,
+      sort,
+      page,
+      addressId,
+    });
+    return data;
+  }
+);
+
 // 매장 상세 정보 조회 API 연동
 export const fetchStoreById = createAsyncThunk(
   "store/fetchStoreById",
@@ -103,6 +117,21 @@ const storeSlice = createSlice({
         state.loading = false;
       })
       .addCase(fetchStoresByCategory.rejected, (state, action) => {
+        state.loading = false;
+        state.error = action.error.message;
+      })
+      // 매장 검색
+      .addCase(fetchStoresByKeyword.pending, (state) => {
+        state.loading = true;
+        state.error = null;
+      })
+      .addCase(fetchStoresByKeyword.fulfilled, (state, action) => {
+        state.stores = action.payload.stores || [];
+        state.currentPage = action.payload.page || 0;
+        state.hasNext = action.payload.hasNext || false;
+        state.loading = false;
+      })
+      .addCase(fetchStoresByKeyword.rejected, (state, action) => {
         state.loading = false;
         state.error = action.error.message;
       })

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -22,5 +22,6 @@ export const STORAGE_KEYS = {
   CURRENT_USER: 'currentUser',
   AUTH_TOKEN: 'authToken',
   ORDERS: 'itseats-orders',
-  FAVORITES: 'itseats-favorites'
+  FAVORITES: 'itseats-favorites',
+  RECENT_SEARCHES: 'itseats-recent-searches',
 }; 


### PR DESCRIPTION
## 연관 이슈
#110
closes #110

## 📌 기능 개요
가게 검색 API를 연동합니다.
Redux slice를 이용하여 최근 검색어를 저장하는 로직을 추가하였습니다.

## 📌 할 일
- [x] 가게 검색 API 연동

액세스 토큰 만료시 리프레시 토큰을 통한 재발급은 백엔드 기능이 개발되지 않아 구현되지 않았습니다. 토큰 만료시 /login 경로로 자동으로 이동됩니다.
또한 현재 기준 itseats-server의 브랜치가 `feat/temporal-token-filter`일 때 동작합니다.

## 📌 참고 사항

![image](https://github.com/user-attachments/assets/b04422e2-1c6a-4dd6-af9e-6dd9b01e2a29)
