### PR TITLE
fix: 브라우저 코드의 환경 체크를 import.meta.env.DEV/PROD로 통일

### DIFF
--- a/docs/API_INTEGRATION_GUIDE.md
+++ b/docs/API_INTEGRATION_GUIDE.md
@@ -48,7 +48,7 @@
 // 로그인 성공 후
 const accessToken = response.headers.get('Access-Token');
 // 개발 환경에서만 사용 권장
-if (process.env.NODE_ENV === 'development') {
+if (import.meta.env.DEV) {
   localStorage.setItem('accessToken', accessToken);
 } else {
   // 프로덕션에서는 httpOnly 쿠키 사용 권장
@@ -64,7 +64,7 @@ API 요청에 토큰을 자동으로 추가하는 인터셉터 설정:
 axios.interceptors.request.use(
   (config) => {
     // 개발 환경: localStorage에서 토큰 가져오기
-    if (process.env.NODE_ENV === 'development') {
+    if (import.meta.env.DEV) {
       const token = localStorage.getItem('accessToken');
       if (token) {
         config.headers.Authorization = `Bearer ${token}`;
@@ -212,7 +212,7 @@ console.log('Request Data:', config.data);
 ### 7.3 토큰 상태 확인
 ```javascript
 // 개발 환경에서만 사용 권장
-if (process.env.NODE_ENV === 'development') {
+if (import.meta.env.DEV) {
   const token = localStorage.getItem('accessToken');
   console.log('Current Token:', token);
 } else {

--- a/docs/TEST_CARDS_CONFIG.md
+++ b/docs/TEST_CARDS_CONFIG.md
@@ -168,7 +168,7 @@ VITE_PAYMENT_TEST_MODE=true
 ### 3. 프로덕션 환경 확인
 ```javascript
 // 프로덕션 환경에서는 테스트 카드 사용 불가
-if (process.env.NODE_ENV === 'production') {
+if (import.meta.env.PROD) {
   console.error('프로덕션 환경에서는 테스트 카드를 사용할 수 없습니다.');
 }
 ```

--- a/src/pages/orders/Order.jsx
+++ b/src/pages/orders/Order.jsx
@@ -65,7 +65,7 @@ export default function Order() {
       if (order.storeId) {
         navigate(`/stores/${order.storeId}`);
       } else {
-        if (process.env.NODE_ENV === "development") {
+        if (import.meta.env.DEV) {
           logger.warn("주문에서 매장 ID를 찾을 수 없습니다:", order);
         }
         const foundStore = allOrders.find((o) => o.storeName === order.storeName);

--- a/src/utils/paymentTestUtils.js
+++ b/src/utils/paymentTestUtils.js
@@ -13,7 +13,7 @@ export class PaymentTestUtils {
 
   // 테스트 모드 확인
   isTestEnvironment() {
-    return this.isTestMode || import.meta.env.NODE_ENV === 'development';
+    return this.isTestMode || import.meta.env.DEV;
   }
 
   // 테스트 카드 정보 반환


### PR DESCRIPTION
## 브라우저 코드의 환경 체크 방식 통일
- 변경 전:
브라우저에서 `process.env.NODE_ENV`로 개발/운영 환경을 체크하는 코드가 일부 남아 있었습니다.
- 변경 후:
Vite 환경에 맞게 모든 브라우저 코드에서
- `process.env.NODE_ENV === 'development' → import.meta.env.DEV`
- `process.env.NODE_ENV === 'production' → import.meta.env.PROD`
로 환경 체크 방식을 통일했습니다.
### 상세 변경 파일
- `src/pages/orders/Order.jsx`
   - 매장 재주문 시 개발 환경 체크 부분을 `import.meta.env.DEV`로 변경
- `src/utils/paymentTestUtils.js`
   - 테스트 환경 체크 함수에서 Vite 방식으로 변경
- `docs/API_INTEGRATION_GUIDE.md`
   - 개발자 혼동 방지를 위해 예시 코드 내 환경 체크도 Vite 방식으로 통일
- `docs/TEST_CARDS_CONFIG.md`
테스트 카드 관련 예시 코드 내 환경 체크도 Vite 방식으로 통일
요약:
브라우저 코드에서 환경 체크는 반드시 `import.meta.env.DEV/PROD`를 사용하도록 일관성 있게 수정하였습니다.
(Node.js 환경 전용 설정 파일 등은 기존 `process.env.NODE_ENV` 사용 유지)
PR 제목 예시:
```
fix: 브라우저 코드 환경 체크 import.meta.env.DEV/PROD로 통일
```
추가 설명이나 상세 변경 내역이 필요하시면 말씀해 주세요!