### PR TITLE
[Refactor] 가게 목록 조회 및 검색 결과 무한 스크롤 적용

### DIFF
--- a/src/components/stores/StoreListItem.jsx
+++ b/src/components/stores/StoreListItem.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import OptimizedImage from "../common/OptimizedImage";
 import styles from "./StoreListItem.module.css";
 
-const StoreListItem = React.memo(({ store, onClick, ref }) => {
+const StoreListItem = React.memo(React.forwardRef(({ store, onClick }, ref) => {
   return (
     <div className={styles.storeListItem} onClick={onClick} ref={ref}>
       <div className={styles.storeImageContainer}>
@@ -46,7 +46,7 @@ const StoreListItem = React.memo(({ store, onClick, ref }) => {
       </div>
     </div>
   );
-});
+}));
 
 StoreListItem.displayName = 'StoreListItem';
 

--- a/src/components/stores/StoreListItem.jsx
+++ b/src/components/stores/StoreListItem.jsx
@@ -2,9 +2,9 @@ import React from "react";
 import OptimizedImage from "../common/OptimizedImage";
 import styles from "./StoreListItem.module.css";
 
-const StoreListItem = React.memo(({ store, onClick }) => {
+const StoreListItem = React.memo(({ store, onClick, ref }) => {
   return (
-    <div className={styles.storeListItem} onClick={onClick}>
+    <div className={styles.storeListItem} onClick={onClick} ref={ref}>
       <div className={styles.storeImageContainer}>
         <OptimizedImage
           src={store.images[0] || "/samples/banner.jpg"}

--- a/src/pages/search/Search.jsx
+++ b/src/pages/search/Search.jsx
@@ -61,7 +61,7 @@ export default function Search() {
       />
       
       {/* 인기 검색어 및 날짜 */}
-      <div>
+      {/* <div>
         <div className={styles.keywordHeader}>
           <span className={styles.title}>인기 검색어</span>
           <span className={styles.subTextRight}>오후 4:10 업데이트</span>
@@ -69,7 +69,7 @@ export default function Search() {
         <div style={{ height: "160px" }}></div>
       </div>
 
-      <hr className={styles.separator}/>
+      <hr className={styles.separator}/> */}
 
       {/* 최근 검색어 */}
       <div>

--- a/src/pages/stores/StoreInfo.jsx
+++ b/src/pages/stores/StoreInfo.jsx
@@ -5,6 +5,7 @@ import SlideInFromRight from "../../components/animation/SlideInFromRight";
 import Header from "../../components/common/Header";
 import { useShare } from "../../hooks/useShare";
 import { fetchStoreById } from "../../store/storeSlice";
+import useAddressRedux from "../../hooks/useAddressRedux";
 
 import styles from "./StoreInfo.module.css";
 import CommonMap from "../../components/common/CommonMap";
@@ -14,19 +15,16 @@ export default function StoreInfo() {
   const dispatch = useDispatch();
   const { copyToClipboardText } = useShare();
   const { storeId } = useParams();
+  const { selectedAddress } = useAddressRedux();
 
   // Redux에서 매장 데이터 가져오기
   const store = useSelector(state => state.store?.currentStore);
-  const stores = useSelector(state => state.store?.stores || []);
   const storeLoading = useSelector(state => state.store?.loading || false);
-  
-  // 현재 매장 데이터 (Redux에서 우선, 없으면 전체 목록에서 검색)
-  const currentStore = store || stores.find(s => s.id === storeId || s.id === parseInt(storeId));
 
   // 사용자 위치 (기본값 - 추후 위치 서비스 연동 가능)
   const userLocation = {
-    lat: 37.501887,
-    lng: 127.039252,
+    lat: selectedAddress?.lat || 37.501887,
+    lng: selectedAddress?.lng || 127.039252,
   };
 
   // 매장 데이터 로딩
@@ -37,7 +35,7 @@ export default function StoreInfo() {
   }, [dispatch, storeId]);
 
   // 로딩 중이거나 매장 데이터가 없는 경우 처리
-  if (storeLoading || !currentStore) {
+  if (storeLoading || !store) {
     return (
       <SlideInFromRight>
         <div className={styles.container}>
@@ -68,12 +66,12 @@ export default function StoreInfo() {
         />
         <div className={styles.map}>
           <CommonMap
-            lat={currentStore.location?.lat || 37.4979}
-            lng={currentStore.location?.lng || 127.0276}
+            lat={store.location?.lat || 37.4979}
+            lng={store.location?.lng || 127.0276}
             markers={[
               {
-                lat: currentStore.location?.lat || 37.4979,
-                lng: currentStore.location?.lng || 127.0276,
+                lat: store.location?.lat || 37.4979,
+                lng: store.location?.lng || 127.0276,
                 type: "store",
               },
               {
@@ -89,23 +87,23 @@ export default function StoreInfo() {
         <div className={styles.storeInfoContainer}>
           <div className={styles.flexContainer}>
             <div>
-              <h2>{currentStore.name}</h2>
-              <p>{currentStore.address || currentStore.location?.address || "주소 정보 없음"}</p>
+              <h2>{store.name}</h2>
+              <p>{store?.address || "주소 정보 없음"}</p>
             </div>
             <p
               className={styles.copyButton}
-              onClick={() => copyToClipboardText(currentStore.address || currentStore.location?.address || "")}
+              onClick={() => copyToClipboardText(store?.address || "")}
             >
               주소복사
             </p>
           </div>
           <div className={styles.businessStatus}>
             <h2>영업상태</h2>
-            <p>{getBusinessStatus(currentStore.businessStatus || "OPEN")}</p>
+            <p>{getBusinessStatus(store.orderable || true)}</p>
           </div>
           <div className={styles.storeDescription}>
             <h2>매장 소개</h2>
-            <p>{currentStore.description || "매장 소개가 없습니다."}</p>
+            <p>{store.description || "매장 소개가 없습니다."}</p>
           </div>
         </div>
       </div>
@@ -113,11 +111,11 @@ export default function StoreInfo() {
   );
 }
 
-function getBusinessStatus(status) {
-  switch (status) {
-    case "OPEN":
+function getBusinessStatus(orderable) {
+  switch (orderable) {
+    case true:
       return "영업 중";
-    case "CLOSED":
+    case false:
       return "영업 종료";
     default:
       return "영업 상태 알 수 없음";

--- a/src/pages/stores/StoreInfo.jsx
+++ b/src/pages/stores/StoreInfo.jsx
@@ -99,7 +99,7 @@ export default function StoreInfo() {
           </div>
           <div className={styles.businessStatus}>
             <h2>영업상태</h2>
-            <p>{getBusinessStatus(store.orderable || true)}</p>
+            <p>{getBusinessStatus(store.orderable)}</p>
           </div>
           <div className={styles.storeDescription}>
             <h2>매장 소개</h2>
@@ -112,12 +112,13 @@ export default function StoreInfo() {
 }
 
 function getBusinessStatus(orderable) {
+  if (orderable === undefined) {
+    return "영업 상태 알 수 없음";
+  }
   switch (orderable) {
     case true:
       return "영업 중";
     case false:
       return "영업 종료";
-    default:
-      return "영업 상태 알 수 없음";
   }
 }

--- a/src/pages/stores/StoreList.jsx
+++ b/src/pages/stores/StoreList.jsx
@@ -58,6 +58,7 @@ export default function StoreList() {
               sort,
               page: currentPage + 1,
               addressId: selectedAddressId,
+              next: true,
             })
           );
         }

--- a/src/pages/stores/StoreList.jsx
+++ b/src/pages/stores/StoreList.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useMemo, useEffect } from "react";
+import React, { useState, useCallback, useRef, useEffect } from "react";
 import { useSelector, useDispatch } from "react-redux";
 import Header from "../../components/common/Header";
 import { useNavigate, useSearchParams } from "react-router-dom";
@@ -8,6 +8,7 @@ import SortBottomSheet, {
   getSortLabel,
 } from "../../components/stores/SortBottomSheet";
 import Tabs from "../../components/stores/Tabs";
+import LoadingSpinner from "../../components/common/LoadingSpinner";
 import { getCategoryName } from "../../utils/categoryUtils";
 import { fetchStoresByCategory } from "../../store/storeSlice";
 import useAddressRedux from "../../hooks/useAddressRedux";
@@ -27,12 +28,44 @@ export default function StoreList() {
   // Redux에서 매장 데이터 가져오기
   const stores = useSelector((state) => state.store?.stores || []);
   const storeLoading = useSelector((state) => state.store?.loading || false);
+  const currentPage = useSelector((state) => state.store?.currentPage || 0);
+  const hasNext = useSelector((state) => state.store?.hasNext || false);
   const { selectedAddressId } = useAddressRedux();
 
   // 매장 데이터 로딩
   useEffect(() => {
-    dispatch(fetchStoresByCategory({ category, sort, page: 0, addressId: selectedAddressId }));
+    dispatch(
+      fetchStoresByCategory({
+        category,
+        sort,
+        page: 0,
+        addressId: selectedAddressId,
+      })
+    );
   }, [dispatch, category, sort, selectedAddressId]);
+
+  // 무한 스크롤 구현
+  const observer = useRef();
+  const lastStoreElementRef = useCallback(
+    (node) => {
+      if (storeLoading) return;
+      if (observer.current) observer.current.disconnect();
+      observer.current = new IntersectionObserver((entries) => {
+        if (entries[0].isIntersecting && hasNext) {
+          dispatch(
+            fetchStoresByCategory({
+              category,
+              sort,
+              page: currentPage + 1,
+              addressId: selectedAddressId,
+            })
+          );
+        }
+      });
+      if (node) observer.current.observe(node);
+    },
+    [storeLoading, hasNext, currentPage, dispatch, category, sort, selectedAddressId]
+  );
 
   // useCallback으로 이벤트 핸들러 최적화
   const handleBackClick = useCallback(() => {
@@ -51,15 +84,21 @@ export default function StoreList() {
     setSortSheetOpen(false);
   }, []);
 
-  const handleSortSelect = useCallback((newSort) => {
-    setSort(newSort);
-    const params = Object.fromEntries(searchParams.entries());
-    setSearchParams({ ...params, sort: newSort }, { replace: true });
-  }, [searchParams, setSearchParams]);
+  const handleSortSelect = useCallback(
+    (newSort) => {
+      setSort(newSort);
+      const params = Object.fromEntries(searchParams.entries());
+      setSearchParams({ ...params, sort: newSort }, { replace: true });
+    },
+    [searchParams, setSearchParams]
+  );
 
-  const handleStoreClick = useCallback((storeId) => {
-    navigate(`/stores/${storeId}`);
-  }, [navigate]);
+  const handleStoreClick = useCallback(
+    (storeId) => {
+      navigate(`/stores/${storeId}`);
+    },
+    [navigate]
+  );
 
   return (
     <SlideInFromRight>
@@ -92,30 +131,38 @@ export default function StoreList() {
               </svg>
             </button>
           </div>
-          {storeLoading ? (
-            <div style={{ padding: '20px', textAlign: 'center' }}>
-              매장 정보를 불러오는 중...
+          {stores.length === 0 && !storeLoading && (
+            <div className={styles.noStoresMessage}>
+              {category
+                ? `${getCategoryName(category)} 매장이 없습니다.`
+                : "매장이 없습니다."}
             </div>
-          ) : stores.length > 0 ? (
-            stores.map((store) => (
-              <StoreListItem
-                key={store.storeId}
-                store={{
-                  storeId: store.storeId,
-                  name: store.name,
-                  review: store.review,
-                  reviewCount: store.reviewCount,
-                  images: store.images || ["/samples/food1.jpg"],
-                  distance: store.distance || 1,
-                  minOrderPrice: store.minOrderPrice || 10000,
-                  minutesToDelivery: parseInt(store.deliveryTime?.split('-')[0]) || 30
-                }}
-                onClick={() => handleStoreClick(store.storeId)}
-              />
-            ))
-          ) : (
-            <div style={{ padding: '20px', textAlign: 'center' }}>
-              {category ? `${getCategoryName(category)} 매장이 없습니다.` : '매장이 없습니다.'}
+          )}
+          {stores.length > 0 &&
+            stores.map((store, index) => {
+              const isLastElement = index === stores.length - 1;
+              return (
+                  <StoreListItem
+                    key={store.storeId}
+                    store={{
+                      storeId: store.storeId,
+                      name: store.name,
+                      review: store.review,
+                      reviewCount: store.reviewCount,
+                      images: store.images || ["/samples/food1.jpg"],
+                      distance: store.distance || 1,
+                      minOrderPrice: store.minOrderPrice || 10000,
+                      minutesToDelivery:
+                        parseInt(store.deliveryTime?.split("-")[0]) || 30,
+                    }}
+                    onClick={() => handleStoreClick(store.storeId)}
+                    ref={isLastElement ? lastStoreElementRef : null}
+                />
+              );
+            })}
+          {storeLoading && (
+            <div style={{ padding: "20px", textAlign: "center" }}>
+              <LoadingSpinner message="매장 정보를 불러오는 중..." />
             </div>
           )}
         </div>

--- a/src/services/storeAPI.js
+++ b/src/services/storeAPI.js
@@ -2,6 +2,7 @@ import apiClient from "./apiClient";
 import { logger } from "../utils/logger";
 import { API_ENDPOINTS } from "../config/api";
 import AuthService from "./authService";
+import { address, desc } from "motion/react-client";
 
 // 재시도 설정
 const RETRY_CONFIG = {
@@ -139,12 +140,11 @@ const StoreAPI = {
             images: storeData.images || [],
             // 기존 프론트엔드 호환성을 위한 추가 필드
             storeImage: storeData.images?.[0] || "/samples/food1.jpg",
-            rating: storeData.reviewRating || 0
+            rating: storeData.reviewRating || 0,
           };
         }
         // 백엔드에서 직접 데이터를 반환하는 경우
         else if (response.data.name) {
-          logger.log("✅ 매장 상세 정보 조회 성공 (직접 데이터):", response.data);
           return {
             storeId: storeId,
             name: response.data.name,
@@ -155,7 +155,15 @@ const StoreAPI = {
             // 기존 프론트엔드 호환성을 위한 추가 필드
             storeImage: response.data.images?.[0] || "/samples/food1.jpg",
             rating: response.data.review || 0,
-            description: response.data.description || ""
+            description: response.data.description || "",
+            address: response.data.address || "",
+            location: {
+              lat: response.data.location?.lat || 37.4979,
+              lng: response.data.location?.lng || 127.0276,
+            },
+            orderable: response.data.orderable || false,
+            defaultDeliveryFee: response.data.defaultDeliveryFee || 0,
+            onlyOneDeliveryFee: response.data.onlyOneDeliveryFee || 0,
           };
         }
       }

--- a/src/services/storeAPI.js
+++ b/src/services/storeAPI.js
@@ -2,7 +2,6 @@ import apiClient from "./apiClient";
 import { logger } from "../utils/logger";
 import { API_ENDPOINTS } from "../config/api";
 import AuthService from "./authService";
-import { address, desc } from "motion/react-client";
 
 // 재시도 설정
 const RETRY_CONFIG = {

--- a/src/store/storeSlice.js
+++ b/src/store/storeSlice.js
@@ -151,6 +151,7 @@ const storeSlice = createSlice({
           state.currentStore.storeId !== action.payload.storeId
         ) {
           state.currentStore = action.payload;
+          console.log("Updating current store with new data:", action.payload);
         } else if (state.currentStore.storeId === action.payload.storeId) {
           // 이미 같은 매장이라면 기존 메뉴를 유지
           state.currentStore = {

--- a/src/store/storeSlice.js
+++ b/src/store/storeSlice.js
@@ -172,7 +172,6 @@ const storeSlice = createSlice({
           state.currentStore.storeId !== action.payload.storeId
         ) {
           state.currentStore = action.payload;
-          console.log("Updating current store with new data:", action.payload);
         } else if (state.currentStore.storeId === action.payload.storeId) {
           // 이미 같은 매장이라면 기존 메뉴를 유지
           state.currentStore = {

--- a/src/store/storeSlice.js
+++ b/src/store/storeSlice.js
@@ -111,7 +111,11 @@ const storeSlice = createSlice({
         state.error = null;
       })
       .addCase(fetchStoresByCategory.fulfilled, (state, action) => {
-        state.stores = action.payload.stores || [];
+        if (action.payload.page === 0) {
+          state.stores = action.payload.stores || [];
+        } else {
+          state.stores = [...state.stores, ...(action.payload.stores || [])];
+        }
         state.currentPage = action.payload.page || 0;
         state.hasNext = action.payload.hasNext || false;
         state.loading = false;


### PR DESCRIPTION
## #️⃣연관된 이슈
#134
closes #134

## 📝작업 내용

- [X] 가게 목록 조회 및 검색 결과 무한 스크롤 적용

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 검색 결과 및 매장 목록 페이지에 무한 스크롤 기능이 추가되어, 스크롤 시 자동으로 추가 매장이 로드됩니다.

* **버그 수정**
  * 매장 상세 정보 페이지에서 매장 상태 및 주소 표시 로직이 간소화되고, 더 정확하게 표시됩니다.

* **개선 사항**
  * 인기 검색어 영역이 검색 페이지에서 비활성화되었습니다.
  * 매장 리스트 및 상세 정보의 로딩 상태와 사용자 피드백이 개선되었습니다.
  * 매장 리스트 항목 컴포넌트가 참조(ref)를 받을 수 있도록 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->